### PR TITLE
Johny b/poc apps 122

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.log
+*.gvmi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # yagna-requests
 
-`startup` might disappear when https://github.com/golemfactory/yagna/issues/1350 is done
+I'd choose one from:
+A)  rename to `yagna-httpx`
+B)  remove httpx integration and
+    B1) use requests "interface" but with `await`s
+        `await session.get()`
+    B2) use requests.Requests explicite
+        `await session.send(Request('GET', ...))`
+    B3) define some other interface?
+    
+    B2 is easier than B1, and B3 is not the best idea imho
+(or maybe there are better options?)
+
+`startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done
 
 Some libraries are required only on the provider side (requests, requests-unixsocket).
 Others are required only on the requestor side (httpx, yapapi-service-manager).
@@ -8,3 +20,6 @@ They are entangled more than they should (e.g. `yagna_requests/serializable_requ
 but only for the stuff running on provider).
 --> untangle this
 --> maybe there are some installation options like `yagna-requests[provider]`?
+
+Load balance --> this should use multi-instance clusters --> consider changes in yapapi-service-manager
+(that's not very important)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # yagna-requests
 
 `startup` might disappear when https://github.com/golemfactory/yagna/issues/1350 is done
+
+Some libraries are required only on the provider side (requests, requests-unixsocket).
+Others are required only on the requestor side (httpx, yapapi-service-manager).
+They are entangled more than they should (e.g. `yagna_requests/serializable_request.py` requires requests
+but only for the stuff running on provider).
+--> untangle this
+--> maybe there are some installation options like `yagna-requests[provider]`?

--- a/README.md
+++ b/README.md
@@ -1,25 +1,43 @@
 # yagna-requests
 
-I'd choose one from:
-A)  rename to `yagna-httpx`
-B)  remove httpx integration and
-    B1) use requests "interface" but with `await`s
-        `await session.get()`
-    B2) use requests.Requests explicite
-        `await session.send(Request('GET', ...))`
-    B3) define some other interface?
-    
-    B2 is easier than B1, and B3 is not the best idea imho
-(or maybe there are better options?)
+## PLANNED FEATURES
 
-`startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done
+* load balancing (assuming stateless services)
+* additional more complex example, with multiple servers
+* (maybe) high availability - recreating services if provider stops responding
 
-Some libraries are required only on the provider side (requests, requests-unixsocket).
+## CURRENT PROBLEMS
+
+### Interface / name
+
+Name `yagna-request` made a lot more sense when we planned to use `requests` library.
+We use `httpx` because it has the `async` interface (and looks like next-gen `requests`).
+
+The only reason to use `httpx` - or `requests` or any other library - is to re-use a popular
+interface. Like in "and this works just like `httpx.AsyncClient` with all it's goodies (timeouts, cookies etc)".
+
+Options:
+
+* A) Rename to `yagna-httpx` or maybe `yagna-httpx-client`, as there is only `client` here.
+* B) Change the interface to look more like requests
+  * B1) recreate requests "interface" but with `await`s -  `await yagna_requests.get(...)`
+  * B2) use requests.Request `await session.send(requests.Request('GET', ...))`
+* C) define some other interface?
+
+I think A) is best - httpx is fine.
+
+### Installation
+
+Currently the same code is installed on the provider and requestor side.
+Some dependencies are required only on the provider side (requests, requests-unixsocket).
 Others are required only on the requestor side (httpx, yapapi-service-manager).
-They are entangled more than they should (e.g. `yagna_requests/serializable_request.py` requires requests
-but only for the stuff running on provider).
---> untangle this
---> maybe there are some installation options like `yagna-requests[provider]`?
 
-Load balance --> this should use multi-instance clusters --> consider changes in yapapi-service-manager
-(that's not very important)
+How to deal with this? 
+Maybe there are some installation options like `yagna-requests[provider]`?
+
+
+## Random notes
+
+* `startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done
+* Load balancing --> this should one day use multi-instance clusters (but not now, because it is not
+  supported in yagna-service-manager and I'm not sure if `yapapi` is ready for e.g. recreating failed providers).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 * additional more complex example, with multiple servers
 
-## Random notes
+## Possible improvements
 
 * `startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done

--- a/README.md
+++ b/README.md
@@ -2,42 +2,8 @@
 
 ## PLANNED FEATURES
 
-* load balancing (assuming stateless services)
 * additional more complex example, with multiple servers
-* (maybe) high availability - recreating services if provider stops responding
-
-## CURRENT PROBLEMS
-
-### Interface / name
-
-Name `yagna-request` made a lot more sense when we planned to use `requests` library.
-We use `httpx` because it has the `async` interface (and looks like next-gen `requests`).
-
-The only reason to use `httpx` - or `requests` or any other library - is to re-use a popular
-interface. Like in "and this works just like `httpx.AsyncClient` with all it's goodies (timeouts, cookies etc)".
-
-Options:
-
-* A) Rename to `yagna-httpx` or maybe `yagna-httpx-client`, as there is only `client` here.
-* B) Change the interface to look more like requests
-  * B1) recreate requests "interface" but with `await`s -  `await yagna_requests.get(...)`
-  * B2) use requests.Request `await session.send(requests.Request('GET', ...))`
-* C) define some other interface?
-
-I think A) is best - httpx is fine.
-
-### Installation
-
-Currently the same code is installed on the provider and requestor side.
-Some dependencies are required only on the provider side (requests, requests-unixsocket).
-Others are required only on the requestor side (httpx, yapapi-service-manager).
-
-How to deal with this? 
-Maybe there are some installation options like `yagna-requests[provider]`?
-
 
 ## Random notes
 
 * `startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done
-* Load balancing --> this should one day use multi-instance clusters (but not now, because it is not
-  supported in yagna-service-manager and I'm not sure if `yapapi` is ready for e.g. recreating failed providers).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # yagna-requests
+
+`startup` might disappear when https://github.com/golemfactory/yagna/issues/1350 is done

--- a/examples/calculator/calculator.Dockerfile
+++ b/examples/calculator/calculator.Dockerfile
@@ -1,14 +1,15 @@
 FROM python:3.8-slim
 
+WORKDIR /golem/work
+VOLUME /golem/work
+
 #   This is necessary only as long as we install yagna-requests from git
 RUN apt-get update && \
     apt-get install -y git
 
-#   NOTE: this is *required* in every image that is supposed to work with yagna-requests
-RUN pip  install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
+#   This is *required* in every image that is supposed to work with yagna-requests
+RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
 
-#   And this is just because our example server is using Flask and running on gunicorn
+#   And this is only calculator-related code. It is implemented in Flask and we use gunicorn to run it.
 RUN pip install Flask==2.0.1 gunicorn==20.1.0
-
-VOLUME /golem/work
-WORKDIR /golem/work
+COPY examples/calculator/calculator_server.py /golem/run/calculator_server.py

--- a/examples/calculator/calculator.Dockerfile
+++ b/examples/calculator/calculator.Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.8-slim
+
+RUN pip install Flask==2.0.1 gunicorn==20.1.0
+
+VOLUME /golem/work
+WORKDIR /golem/work

--- a/examples/calculator/calculator.Dockerfile
+++ b/examples/calculator/calculator.Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.8-slim
 
+#   NOTE: this is *required* in every image that is supposed to work with yagna-requests
+RUN pip  install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
+
+#   And this is just because our example server is using Flask and running on gunicorn
 RUN pip install Flask==2.0.1 gunicorn==20.1.0
 
 VOLUME /golem/work

--- a/examples/calculator/calculator.Dockerfile
+++ b/examples/calculator/calculator.Dockerfile
@@ -10,6 +10,6 @@ RUN apt-get update && \
 #   This is *required* in every image that is supposed to work with yagna-requests
 RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
 
-#   And this is only calculator-related code. It is implemented in Flask and we use gunicorn to run it.
+#   And this is calculator-related code (this part will be different in other examples). 
 RUN pip install Flask==2.0.1 gunicorn==20.1.0
 COPY examples/calculator/calculator_server.py /golem/run/calculator_server.py

--- a/examples/calculator/calculator.Dockerfile
+++ b/examples/calculator/calculator.Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.8-slim
 
+#   This is necessary only as long as we install yagna-requests from git
+RUN apt-get update && \
+    apt-get install -y git
+
 #   NOTE: this is *required* in every image that is supposed to work with yagna-requests
 RUN pip  install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
 

--- a/examples/calculator/calculator_server.py
+++ b/examples/calculator/calculator_server.py
@@ -1,0 +1,8 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route('/add/<int:a>/<int:b>', methods=['GET'])
+def add(a, b):
+    return str(a + b), 200

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -1,0 +1,36 @@
+from yagna_requests import Session
+from os import path
+import asyncio
+
+executor_cfg = {'budget': 1, 'subnet_tag': 'devnet-beta.2'}
+session = Session(executor_cfg)
+
+
+@session.startup('http://calculator', 'd44c88b6c3d4a5f6e645a9e7f9ebab2cc171f402ef11da088c2d62e8')
+def calculator_startup(ctx, listen_on):
+    ctx.send_file('examples/calculator/calculator_server.py', path.join('/golem/work/calculator_server.py'))
+    # ctx.send_file('process_request.py', path.join('/golem/work/process_request.py'))
+    # ctx.send_file('serializable_request.py', path.join('/golem/work/serializable_request.py'))
+    ctx.run("/usr/local/bin/gunicorn", "-b", listen_on, "calculator_server:app", "--daemon")
+
+
+async def run_calculator():
+    async with session.client() as client:
+        res = await client.get('https://www.example.org/')
+        print(res)
+    
+    await session.close()
+
+def main():
+    try:
+        loop = asyncio.get_event_loop()
+        run_calculator_task = loop.create_task(run_calculator())
+        loop.run_until_complete(run_calculator_task)
+    except KeyboardInterrupt:
+        shutdown = loop.create_task(session.close())
+        loop.run_until_complete(shutdown)
+        run_calculator_task.cancel()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -6,24 +6,20 @@ executor_cfg = {'budget': 1, 'subnet_tag': 'devnet-beta.2'}
 session = Session(executor_cfg)
 
 
-@session.startup('http://calculator', '040e5b765dcf008d037d5b840cf8a9678641b0ddd3b4fe3226591a11')
+@session.startup('http://calc', '040e5b765dcf008d037d5b840cf8a9678641b0ddd3b4fe3226591a11')
 def calculator_startup(ctx, listen_on):
     ctx.run("/usr/local/bin/gunicorn", "--chdir", "/golem/run", "-b", listen_on, "calculator_server:app", "--daemon")
 
 
 async def run_calculator():
     async with session.client() as client:
+        for x, y in ((1, 2), (7, 8)):
+            res = await client.get(f'http://calc/add/{x}/{y}')
+            print(f"CALCULATED: {x} + {y} =", res.content.decode())
+
+        #   NOTE: requests sent somewhere else work exactly as in httpx.AsyncClient()
         res = await client.get('https://www.example.org/')
         print("EXAMPLE ORG", res)
-
-        from yagna_requests.serializable_request import Request
-        req = Request.from_file('sample_request.json')
-        res = await session.send('http://calculator', req)
-        print("SAMPLE REQUEST", res.status, res.data)
-
-        req = Request.from_file('sample_request.json')
-        res = await session.send('http://calculator', req)
-        print("SAMPLE REQUEST 2", res.status, res.data)
 
     await session.close()
 

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -2,7 +2,7 @@ import asyncio
 
 from yagna_requests import Session
 
-executor_cfg = {'budget': 1, 'subnet_tag': 'devnet-beta.2'}
+executor_cfg = {'budget': 10, 'subnet_tag': 'devnet-beta.2'}
 session = Session(executor_cfg)
 
 
@@ -20,8 +20,8 @@ async def add(client, x, y):
 async def run_calculator():
     async with session.client() as client:
         requests = []
-        for x in range(0, 5):
-            for y in range(0, 5):
+        for x in range(0, 50):
+            for y in range(0, 50):
                 requests.append(add(client, x, y))
         await asyncio.gather(*requests)
 

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -6,7 +6,11 @@ executor_cfg = {'budget': 10, 'subnet_tag': 'devnet-beta.2'}
 session = Session(executor_cfg)
 
 
-@session.startup('http://calc', '040e5b765dcf008d037d5b840cf8a9678641b0ddd3b4fe3226591a11', 3)
+@session.startup(
+    url='http://calc',
+    image_hash='040e5b765dcf008d037d5b840cf8a9678641b0ddd3b4fe3226591a11',
+    service_cnt=3,
+)
 def calculator_startup(ctx, listen_on):
     ctx.run("/usr/local/bin/gunicorn", "--chdir", "/golem/run", "-b", listen_on, "calculator_server:app", "--daemon")
 

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -1,16 +1,15 @@
-from yagna_requests import Session
-from os import path
 import asyncio
+from os import path
+
+from yagna_requests import Session
 
 executor_cfg = {'budget': 1, 'subnet_tag': 'devnet-beta.2'}
 session = Session(executor_cfg)
 
 
-@session.startup('http://calculator', 'd44c88b6c3d4a5f6e645a9e7f9ebab2cc171f402ef11da088c2d62e8')
+@session.startup('http://calculator', '855c7b4bba2ff00005a52bf29048130e8648955b020e1735b6da7fe4')
 def calculator_startup(ctx, listen_on):
     ctx.send_file('examples/calculator/calculator_server.py', path.join('/golem/work/calculator_server.py'))
-    # ctx.send_file('process_request.py', path.join('/golem/work/process_request.py'))
-    # ctx.send_file('serializable_request.py', path.join('/golem/work/serializable_request.py'))
     ctx.run("/usr/local/bin/gunicorn", "-b", listen_on, "calculator_server:app", "--daemon")
 
 
@@ -19,6 +18,7 @@ async def run_calculator():
         res = await client.get('https://www.example.org/')
         print(res)
     
+    await asyncio.Future()
     await session.close()
 
 def main():

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -16,10 +16,19 @@ def calculator_startup(ctx, listen_on):
 async def run_calculator():
     async with session.client() as client:
         res = await client.get('https://www.example.org/')
-        print(res)
-    
-    await asyncio.Future()
+        print("EXAMPLE ORG", res)
+
+        from yagna_requests.serializable_request import Request
+        req = Request.from_file('sample_request.json')
+        res = await session.send('http://calculator', req)
+        print("SAMPLE REQUEST", res.status, res.data)
+        
+        req = Request.from_file('sample_request.json')
+        res = await session.send('http://calculator', req)
+        print("SAMPLE REQUEST 2", res.status, res.data)
+
     await session.close()
+
 
 def main():
     try:

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -1,5 +1,4 @@
 import asyncio
-from os import path
 
 from yagna_requests import Session
 
@@ -7,10 +6,9 @@ executor_cfg = {'budget': 1, 'subnet_tag': 'devnet-beta.2'}
 session = Session(executor_cfg)
 
 
-@session.startup('http://calculator', '855c7b4bba2ff00005a52bf29048130e8648955b020e1735b6da7fe4')
+@session.startup('http://calculator', '040e5b765dcf008d037d5b840cf8a9678641b0ddd3b4fe3226591a11')
 def calculator_startup(ctx, listen_on):
-    ctx.send_file('examples/calculator/calculator_server.py', path.join('/golem/work/calculator_server.py'))
-    ctx.run("/usr/local/bin/gunicorn", "-b", listen_on, "calculator_server:app", "--daemon")
+    ctx.run("/usr/local/bin/gunicorn", "--chdir", "/golem/run", "-b", listen_on, "calculator_server:app", "--daemon")
 
 
 async def run_calculator():
@@ -22,7 +20,7 @@ async def run_calculator():
         req = Request.from_file('sample_request.json')
         res = await session.send('http://calculator', req)
         print("SAMPLE REQUEST", res.status, res.data)
-        
+
         req = Request.from_file('sample_request.json')
         res = await session.send('http://calculator', req)
         print("SAMPLE REQUEST 2", res.status, res.data)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://handbook.golem.network/yapapi/",
     download_url="https://github.com/golemfactory/yagna-requests",
     packages=setuptools.find_packages(),
-    install_requires=["requests==2.25.1", "requests-unixsocket==0.2.0", "http==0.18.2"],
+    install_requires=["requests==2.25.1", "requests-unixsocket==0.2.0", "httpx==0.18.2"],
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "requests==2.25.1",
         "requests-unixsocket==0.2.0",
         "httpx==0.18.2",
-        "yapapi-service-manager git+https://github.com/golemfactory/yapapi-service-manager.git",
+        "yapapi-service-manager @ git+https://github.com/golemfactory/yapapi-service-manager.git",
     ],
     classifiers=[
         "Development Status :: 0 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "requests==2.25.1",
         "requests-unixsocket==0.2.0",
         "httpx==0.18.2",
-        "git+https://github.com/golemfactory/yapapi-service-manager.git",
+        "yapapi-service-manager git+https://github.com/golemfactory/yapapi-service-manager.git",
     ],
     classifiers=[
         "Development Status :: 0 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://handbook.golem.network/yapapi/",
     download_url="https://github.com/golemfactory/yagna-requests",
     packages=setuptools.find_packages(),
-    install_requires=["requests==2.25.1", "requests-unixsocket==0.2.0"],
+    install_requires=["requests==2.25.1", "requests-unixsocket==0.2.0", "http==0.18.2"],
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,12 @@ setuptools.setup(
     url="https://handbook.golem.network/yapapi/",
     download_url="https://github.com/golemfactory/yagna-requests",
     packages=setuptools.find_packages(),
-    install_requires=["requests==2.25.1", "requests-unixsocket==0.2.0", "httpx==0.18.2"],
+    install_requires=[
+        "requests==2.25.1",
+        "requests-unixsocket==0.2.0",
+        "httpx==0.18.2",
+        "git+https://github.com/golemfactory/yapapi-service-manager.git",
+    ],
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="yagna-requests",
+    version="0.0.0",
+    author="Golem Factory, Jan Betley",
+    author_email="contact@golem.network, jan.betley@golem.network",
+    description="send requests to the server running on a provider",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://handbook.golem.network/yapapi/",
+    download_url="https://github.com/golemfactory/yagna-requests",
+    packages=setuptools.find_packages(),
+    install_requires=["requests==2.25.1", "requests-unixsocket==0.2.0"],
+    classifiers=[
+        "Development Status :: 0 - Alpha",
+        "Framework :: YaPaPI",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: System :: Distributed Computing",
+    ],
+    python_requires=">=3.6.1",
+)

--- a/yagna_requests/__init__.py
+++ b/yagna_requests/__init__.py
@@ -1,0 +1,1 @@
+from .session import Session

--- a/yagna_requests/__main__.py
+++ b/yagna_requests/__main__.py
@@ -1,1 +1,57 @@
-print("RUNNING YAGNA REQUESTS")
+import click
+from yagna_requests.serializable_request import Request, Response
+import requests_unixsocket
+
+
+@click.command()
+@click.option('--url', required=True)
+@click.argument('request_path')
+@click.argument('response_path')
+def process_request(url, request_path, response_path):
+    url = _adjust_url(url)
+
+    req = Request.from_file(request_path)
+    req.replace_mount_url(url)
+
+    requests_req = req.as_requests_request()
+    session = requests_unixsocket.Session()
+    requests_res = session.send(requests_req.prepare())
+
+    res = Response.from_requests_response(requests_res)
+    res.to_file(response_path)
+
+    print(f"IN:  {request_path}")
+    print(f"OUT: {response_path}")
+
+
+def _adjust_url(url):
+    '''
+    Only current usecase:
+        unix:///tmp/golem.sock/  --> http+unix://%2Ftmp%2Fgolem.sock
+        
+    NOTE: urllib.parse is not used, because it doesn't work well with urls with empty host,
+          e.g. with the one above
+    '''
+    if '://' not in url:
+        raise ValueError(f"Missing schema in url {url}")
+
+    schema, no_schema_url = url.split('://', 1)
+    if schema == 'unix':
+        #   This is required by requests_unixsocket
+        schema = 'http+unix'
+
+    if no_schema_url.endswith('/'):
+        no_schema_url = no_schema_url[:-1]
+
+    if no_schema_url.startswith('/'):
+        #   If this is a no-host url, and we don't url-encode all '/',
+        #   requests assume the path is the host.
+        #   Also we can't use ullib.parse.quote, because some part might
+        #   already be url-encoded.
+        no_schema_url = no_schema_url.replace('/', '%2F')
+
+    return '://'.join([schema, no_schema_url])
+
+
+if __name__ == '__main__':
+    process_request()

--- a/yagna_requests/__main__.py
+++ b/yagna_requests/__main__.py
@@ -1,0 +1,1 @@
+print("RUNNING YAGNA REQUESTS")

--- a/yagna_requests/serializable_request.py
+++ b/yagna_requests/serializable_request.py
@@ -56,13 +56,15 @@ class Request:
         if '://' not in new_base_url:
             raise ValueError(f"Missing schema in url {new_base_url}")
 
-        old_url_parts = list(urlsplit(self.url))
-        old_base_url_parts = old_url_parts[:2] + ['', '', '']
-        old_base_url = urlunsplit(old_base_url_parts)
-
         new_base_url = new_base_url.rstrip('/')
 
-        self.url = self.url.replace(old_base_url, new_base_url, 1)
+        self.url = self.url.replace(self.base_url, new_base_url, 1)
+
+    @property
+    def base_url(self):
+        url_parts = list(urlsplit(self.url))
+        base_url_parts = url_parts[:2] + ['', '', '']
+        return urlunsplit(base_url_parts)
 
     @classmethod
     def from_flask_request(cls):

--- a/yagna_requests/serializable_request.py
+++ b/yagna_requests/serializable_request.py
@@ -1,0 +1,116 @@
+import requests
+import json
+from urllib.parse import urlsplit, urlunsplit
+
+
+class Response():
+    def __init__(self, status, data, headers):
+        self.status = status
+        self.data = data
+        self.headers = headers
+
+    @classmethod
+    def from_file(cls, fname):
+        with open(fname, 'r') as f:
+            return cls.from_json(f.read())
+
+    @classmethod
+    def from_json(cls, json_data):
+        data = json.loads(json_data)
+        return cls(
+            int(data['status']),
+            data['data'].encode('utf-8'),
+            data['headers'],
+        )
+
+    @classmethod
+    def from_requests_response(cls, res: requests.Response):
+        return cls(res.status_code, res.content, dict(res.headers))
+
+    def to_file(self, fname):
+        with open(fname, 'w') as f:
+            f.write(self.as_json())
+
+    def as_json(self):
+        return json.dumps(self.as_dict())
+
+    def as_dict(self):
+        return {
+            'status': self.status,
+            'data': self.data.decode('utf-8'),
+            'headers': self.headers,
+        }
+
+    def as_flask_response(self):
+        return self.data.decode('utf-8'), self.status, self.headers
+
+
+class Request():
+    def __init__(self, method, url, data, headers):
+        self.method = method
+        self.url = url
+        self.data = data
+        self.headers = headers
+
+    def replace_mount_url(self, new_base_url):
+        if '://' not in new_base_url:
+            raise ValueError(f"Missing schema in url {new_base_url}")
+
+        old_url_parts = list(urlsplit(self.url))
+        old_base_url_parts = old_url_parts[:2] + ['', '', '']
+        old_base_url = urlunsplit(old_base_url_parts)
+
+        if new_base_url.endswith('/'):
+            new_base_url = new_base_url[:-1]
+
+        self.url = self.url.replace(old_base_url, new_base_url, 1)
+
+    @classmethod
+    def from_flask_request(cls):
+        from flask import request
+        return cls(request.method, request.url, request.get_data(), dict(request.headers))
+
+    @classmethod
+    async def from_quart_request(cls):
+        from quart import request
+        data = await request.get_data()
+        return cls(request.method, request.url, data, dict(request.headers))
+
+    @classmethod
+    def from_file(cls, fname):
+        with open(fname, 'r') as f:
+            return cls.from_json(f.read())
+
+    @classmethod
+    def from_json(cls, json_data):
+        data = json.loads(json_data)
+        return cls(
+            data['method'],
+            data['url'],
+            data['data'].encode('utf-8'),
+            data['headers'],
+        )
+
+    def to_file(self, fname):
+        with open(fname, 'w') as f:
+            f.write(self.as_json())
+
+    def as_json(self):
+        return json.dumps(self.as_dict())
+
+    def as_dict(self):
+        return {
+            'method': self.method,
+            'url': self.url,
+            'data': self.data.decode('utf-8'),
+            'headers': self.headers,
+        }
+
+    def as_requests_request(self):
+        req = requests.Request(
+            method=self.method,
+            url=self.url,
+            data=self.data,
+            headers=self.headers,
+        )
+        return req

--- a/yagna_requests/serializable_request.py
+++ b/yagna_requests/serializable_request.py
@@ -3,7 +3,7 @@ import json
 from urllib.parse import urlsplit, urlunsplit
 
 
-class Response():
+class Response:
     def __init__(self, status, data, headers):
         self.status = status
         self.data = data
@@ -45,7 +45,7 @@ class Response():
         return self.data.decode('utf-8'), self.status, self.headers
 
 
-class Request():
+class Request:
     def __init__(self, method, url, data, headers):
         self.method = method
         self.url = url
@@ -60,8 +60,7 @@ class Request():
         old_base_url_parts = old_url_parts[:2] + ['', '', '']
         old_base_url = urlunsplit(old_base_url_parts)
 
-        if new_base_url.endswith('/'):
-            new_base_url = new_base_url[:-1]
+        new_base_url = new_base_url.rstrip('/')
 
         self.url = self.url.replace(old_base_url, new_base_url, 1)
 

--- a/yagna_requests/serializable_request.py
+++ b/yagna_requests/serializable_request.py
@@ -91,6 +91,23 @@ class Request():
             data['headers'],
         )
 
+    @classmethod
+    def from_httpx_handle_request_args(cls, method, url, headers, stream):
+        method = method.decode()
+
+        scheme, host, port, path = url
+        scheme, host, path = scheme.decode(), host.decode(), path.decode()
+
+        if port is None:
+            url = f'{scheme}://{host}{path}'
+        else:
+            url = f'{scheme}://{host}:{port}{path}'
+
+        headers = {key.decode(): val.decode() for key, val in headers}
+        data = stream.read()
+
+        return cls(method, url, data, headers)
+
     def to_file(self, fname):
         with open(fname, 'w') as f:
             f.write(self.as_json())

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -24,7 +24,7 @@ class ServiceBase(Service):
         queue = self._service_def['queue']
         while True:
             req, fut = await queue.get()
-            print("GOT REQ", req)
+            print(f"processing {req.url} on {self.provider_name}")
             with NamedTemporaryFile() as in_file, NamedTemporaryFile() as out_file:
                 req.to_file(in_file.name)
                 self._ctx.send_file(in_file.name, '/golem/work/req.json')

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -11,17 +11,17 @@ PROVIDER_URL = 'unix:///tmp/golem.sock'
 class ServiceBase(Service):
     @classmethod
     async def get_payload(cls):
-        print("SERVICE DEF", cls._service_def)
-        return await vm.repo(image_hash=cls._service_def['image_hash'])
+        image_hash = cls._yhc_cluster.image_hash
+        return await vm.repo(image_hash=image_hash)
 
     async def start(self):
-        start_steps = self._service_def['start_steps']
+        start_steps = self._yhc_cluster.start_steps
         start_steps(self._ctx, PROVIDER_URL)
         yield self._ctx.commit()
         print("STARTED")
 
     async def run(self):
-        queue = self._service_def['queue']
+        queue = self._yhc_cluster.request_queue
         while True:
             req, fut = await queue.get()
             print(f"processing {req.url} on {self.provider_name}")

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -1,0 +1,20 @@
+
+from yapapi.services import Service
+from yapapi.payload import vm
+
+
+PROVIDER_SERVER_URL = 'unix:///tmp/golem.sock'
+
+
+class ServiceBase(Service):
+    @classmethod
+    async def get_payload(cls):
+        print("SERVICE DEF", cls._service_def)
+        return await vm.repo(image_hash=cls._service_def['image_hash'])
+
+    async def start(self):
+        start_steps = self._service_def['start_steps']
+        start_steps(self._ctx, PROVIDER_SERVER_URL)
+        self._ctx.run('/bin/ls', '-l')
+        res = yield self._ctx.commit()
+        print("STARTED")

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -26,7 +26,7 @@ class ServiceBase(Service):
         start_steps = self._yhc_cluster.start_steps
         start_steps(self._ctx, PROVIDER_URL)
         yield self._ctx.commit()
-        print("STARTED")
+        print(f"STARTED ON {self.provider_name}")
 
     async def run(self):
         while True:
@@ -41,8 +41,8 @@ class ServiceBase(Service):
 
                 #   FAIL ON PURPOSE, SOMETIMES
                 #   TODO: remove this
-                if random.random() < 0.01:
-                    raise Exception("oooops")
+                if random.random() < 0.1:
+                    raise Exception(f"oooops, failed on request {req.url}")
 
                 res = Response.from_file(out_file.name)
 

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -1,5 +1,4 @@
 from tempfile import NamedTemporaryFile
-import random
 
 from yapapi.services import Service
 from yapapi.payload import vm
@@ -39,13 +38,7 @@ class ServiceBase(Service):
                 self._ctx.download_file('/golem/work/res.json', out_file.name)
                 yield self._ctx.commit()
 
-                #   FAIL ON PURPOSE, SOMETIMES
-                #   TODO: remove this
-                if random.random() < 0.1:
-                    raise Exception(f"oooops, failed on request {req.url}")
-
                 res = Response.from_file(out_file.name)
-
                 fut.set_result(res)
 
     def restart_failed_request(self):

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -1,12 +1,19 @@
+import asyncio
+from tempfile import NamedTemporaryFile
 
 from yapapi.services import Service
 from yapapi.payload import vm
 
+from .serializable_request import Response
 
 PROVIDER_SERVER_URL = 'unix:///tmp/golem.sock'
 
 
 class ServiceBase(Service):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.commit_queue = asyncio.Queue()
+
     @classmethod
     async def get_payload(cls):
         print("SERVICE DEF", cls._service_def)
@@ -20,10 +27,27 @@ class ServiceBase(Service):
         print("STARTED")
 
     async def run(self):
-        print("RUN")
-        self._ctx.send_file('sample_request.json', '/golem/work/req.json')
-        self._ctx.run('/bin/sh', '-c', f'python -m yagna_requests --url {PROVIDER_SERVER_URL} req.json res.json')
-        self._ctx.download_file('/golem/work/res.json', 'res.json')
-        res = yield self._ctx.commit()
-        from pprint import pprint
-        pprint(res)
+        while True:
+            fut = await self.commit_queue.get()
+            res = yield self._ctx.commit()
+            fut.set_result(res.result())
+
+    async def commit(self):
+        fut = asyncio.get_running_loop().create_future()
+        self.commit_queue.put_nowait(fut)
+        await fut
+        return fut.result()
+
+    async def send(self, req):
+        with NamedTemporaryFile() as in_file, NamedTemporaryFile() as out_file:
+            req.to_file(in_file.name)
+            self._ctx.send_file(in_file.name, '/golem/work/req.json')
+            self._ctx.run('/bin/sh', '-c', f'python -m yagna_requests --url {PROVIDER_SERVER_URL} req.json res.json')
+            self._ctx.download_file('/golem/work/res.json', out_file.name)
+
+            await self.commit()
+
+            res = Response.from_file(out_file.name)
+            return res
+
+        return res

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -9,6 +9,13 @@ PROVIDER_URL = 'unix:///tmp/golem.sock'
 
 
 class ServiceBase(Service):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.queue = self._yhc_cluster.request_queue
+
+        self.current_req, self.current_fut = None, None
+
     @classmethod
     async def get_payload(cls):
         image_hash = cls._yhc_cluster.image_hash
@@ -21,17 +28,24 @@ class ServiceBase(Service):
         print("STARTED")
 
     async def run(self):
-        queue = self._yhc_cluster.request_queue
         while True:
-            req, fut = await queue.get()
+            req, fut = self.current_req, self.current_fut = await self.queue.get()
             print(f"processing {req.url} on {self.provider_name}")
             with NamedTemporaryFile() as in_file, NamedTemporaryFile() as out_file:
                 req.to_file(in_file.name)
                 self._ctx.send_file(in_file.name, '/golem/work/req.json')
                 self._ctx.run('/bin/sh', '-c', f'python -m yagna_requests --url {PROVIDER_URL} req.json res.json')
                 self._ctx.download_file('/golem/work/res.json', out_file.name)
-
                 yield self._ctx.commit()
 
                 res = Response.from_file(out_file.name)
+
+                #   FAIL ON PURPOSE, SOMETIMES (dev)
+                # if self.queue.qsize() > 5 and ('0/3' in req.url or '2/4' in req.url):
+                #     raise Exception("oooops")
+
                 fut.set_result(res)
+
+    def restart_failed_request(self):
+        if self.current_fut is not None and not self.current_fut.done():
+            self.queue.put_nowait((self.current_req, self.current_fut))

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -16,5 +16,14 @@ class ServiceBase(Service):
         start_steps = self._service_def['start_steps']
         start_steps(self._ctx, PROVIDER_SERVER_URL)
         self._ctx.run('/bin/ls', '-l')
-        res = yield self._ctx.commit()
+        yield self._ctx.commit()
         print("STARTED")
+
+    async def run(self):
+        print("RUN")
+        self._ctx.send_file('sample_request.json', '/golem/work/req.json')
+        self._ctx.run('/bin/sh', '-c', f'python -m yagna_requests --url {PROVIDER_SERVER_URL} req.json res.json')
+        self._ctx.download_file('/golem/work/res.json', 'res.json')
+        res = yield self._ctx.commit()
+        from pprint import pprint
+        pprint(res)

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -1,4 +1,3 @@
-import asyncio
 from tempfile import NamedTemporaryFile
 
 from yapapi.services import Service
@@ -6,14 +5,10 @@ from yapapi.payload import vm
 
 from .serializable_request import Response
 
-PROVIDER_SERVER_URL = 'unix:///tmp/golem.sock'
+PROVIDER_URL = 'unix:///tmp/golem.sock'
 
 
 class ServiceBase(Service):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.commit_queue = asyncio.Queue()
-
     @classmethod
     async def get_payload(cls):
         print("SERVICE DEF", cls._service_def)
@@ -21,32 +16,22 @@ class ServiceBase(Service):
 
     async def start(self):
         start_steps = self._service_def['start_steps']
-        start_steps(self._ctx, PROVIDER_SERVER_URL)
+        start_steps(self._ctx, PROVIDER_URL)
         yield self._ctx.commit()
         print("STARTED")
 
     async def run(self):
+        queue = self._service_def['queue']
         while True:
-            fut = await self.commit_queue.get()
-            res = yield self._ctx.commit()
-            fut.set_result(res.result())
+            req, fut = await queue.get()
+            print("GOT REQ", req)
+            with NamedTemporaryFile() as in_file, NamedTemporaryFile() as out_file:
+                req.to_file(in_file.name)
+                self._ctx.send_file(in_file.name, '/golem/work/req.json')
+                self._ctx.run('/bin/sh', '-c', f'python -m yagna_requests --url {PROVIDER_URL} req.json res.json')
+                self._ctx.download_file('/golem/work/res.json', out_file.name)
 
-    async def commit(self):
-        fut = asyncio.get_running_loop().create_future()
-        self.commit_queue.put_nowait(fut)
-        await fut
-        return fut.result()
+                yield self._ctx.commit()
 
-    async def send(self, req):
-        with NamedTemporaryFile() as in_file, NamedTemporaryFile() as out_file:
-            req.to_file(in_file.name)
-            self._ctx.send_file(in_file.name, '/golem/work/req.json')
-            self._ctx.run('/bin/sh', '-c', f'python -m yagna_requests --url {PROVIDER_SERVER_URL} req.json res.json')
-            self._ctx.download_file('/golem/work/res.json', out_file.name)
-
-            await self.commit()
-
-            res = Response.from_file(out_file.name)
-            return res
-
-        return res
+                res = Response.from_file(out_file.name)
+                fut.set_result(res)

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -1,4 +1,5 @@
 from tempfile import NamedTemporaryFile
+import random
 
 from yapapi.services import Service
 from yapapi.payload import vm
@@ -38,11 +39,12 @@ class ServiceBase(Service):
                 self._ctx.download_file('/golem/work/res.json', out_file.name)
                 yield self._ctx.commit()
 
-                res = Response.from_file(out_file.name)
+                #   FAIL ON PURPOSE, SOMETIMES
+                #   TODO: remove this
+                if random.random() < 0.01:
+                    raise Exception("oooops")
 
-                #   FAIL ON PURPOSE, SOMETIMES (dev)
-                # if self.queue.qsize() > 5 and ('0/3' in req.url or '2/4' in req.url):
-                #     raise Exception("oooops")
+                res = Response.from_file(out_file.name)
 
                 fut.set_result(res)
 

--- a/yagna_requests/service_base.py
+++ b/yagna_requests/service_base.py
@@ -22,7 +22,6 @@ class ServiceBase(Service):
     async def start(self):
         start_steps = self._service_def['start_steps']
         start_steps(self._ctx, PROVIDER_SERVER_URL)
-        self._ctx.run('/bin/ls', '-l')
         yield self._ctx.commit()
         print("STARTED")
 

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -76,8 +76,7 @@ class YagnaTransport(httpx.AsyncBaseTransport):
         req = Request.from_httpx_handle_request_args(method, url, headers, stream)
         fut = asyncio.Future()
         self.request_queue.put_nowait((req, fut))
-        await fut
-        res = fut.result()
+        res = await fut
         return res.status, res.headers, httpx.ByteStream(res.data), {}
 
 

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -40,7 +40,7 @@ class Cluster:
             if service_wrapper.status in ('pending', 'starting'):
                 print(f"waiting for the service, current status: {service_wrapper.status}")
             elif service_wrapper.status == 'running':
-                print(f"Service {service_wrapper.service.provider_name} is running")
+                pass
             else:
                 print(f"Restarting service because it is {service_wrapper.status}")
                 service_wrapper.service.restart_failed_request()
@@ -75,12 +75,12 @@ class Session:
         self.manager = ServiceManager(executor_cfg)
         self.clusters = {}
 
-    def startup(self, url, image_hash, cnt=1):
+    def startup(self, url, image_hash, service_cnt=1):
         if url in self.clusters:
             raise KeyError(f'Service for url {url} already exists')
 
         def define_service(start_steps):
-            self.clusters[url] = Cluster(self.manager, image_hash, start_steps, cnt)
+            self.clusters[url] = Cluster(self.manager, image_hash, start_steps, service_cnt)
 
         return define_service
 

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -23,6 +23,10 @@ class Session:
 
         return define_service
 
+    async def send(self, url, req):
+        service = self.service_wrappers[url].service
+        return await service.send(req)
+
     @asynccontextmanager
     async def client(self, *args, **kwargs):
         await self.start_new_services()

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -33,7 +33,8 @@ class Cluster:
         self.manager_tasks += [asyncio.create_task(self._manage()) for _ in range(current_cnt, self.cnt)]
 
     def stop(self):
-        [task.cancel() for task in self.manager_tasks]
+        for task in self.manager_tasks:
+            task.cancel()
 
     async def _manage(self):
         service_wrapper = None
@@ -106,8 +107,10 @@ class Session:
             yield client
 
     def start_new_services(self):
-        [cluster.start() for cluster in self.clusters.values()]
+        for cluster in self.clusters.values():
+            cluster.start()
 
     async def close(self):
-        [cluster.stop() for cluster in self.clusters.values()]
+        for cluster in self.clusters.values():
+            cluster.stop()
         await self.manager.close()

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -40,7 +40,7 @@ class Cluster:
             if service_wrapper.status in ('pending', 'starting'):
                 print(f"waiting for the service, current status: {service_wrapper.status}")
             elif service_wrapper.status == 'running':
-                pass
+                print(f"Service {service_wrapper.service.provider_name} is running")
             else:
                 print(f"Restarting service because it is {service_wrapper.status}")
                 service_wrapper.service.restart_failed_request()

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -27,7 +27,7 @@ class Session:
         self.manager = ServiceManager(executor_cfg)
         self.service_defs = {}
 
-    def startup(self, url, image_hash):
+    def startup(self, url, image_hash, cnt=1):
         if url in self.service_defs:
             raise KeyError(f'Service for url {url} already exists')
 
@@ -37,7 +37,7 @@ class Session:
                 'image_hash': image_hash,
                 'start_steps': start_steps,
                 'queue': request_queue,
-                'cnt': 1,
+                'cnt': cnt,
                 'service_wrappers': []
             }
 

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -1,5 +1,5 @@
-import re
 import asyncio
+import uuid
 from contextlib import asynccontextmanager
 
 import httpx
@@ -7,6 +7,38 @@ from yapapi_service_manager import ServiceManager
 
 from .service_base import ServiceBase
 from .serializable_request import Request
+
+
+class Cluster:
+    def __init__(self, manager, image_hash, start_steps, cnt):
+        self.manager = manager
+        self.image_hash = image_hash
+        self.start_steps = start_steps
+        self.cnt = cnt
+
+        self.request_queue = asyncio.Queue()
+        self.cls = self._create_cls()
+
+        self.manager_tasks = []
+
+    def start(self):
+        current_cnt = len(self.manager_tasks)
+        [asyncio.create_task(self._manage()) for _ in range(current_cnt, self.cnt)]
+
+    def stop(self):
+        [task.cancel() for task in self.manager_tasks]
+
+    async def _manage(self):
+        service_wrapper = self.manager.create_service(self.cls)
+
+        while True:
+            print(f"status: {service_wrapper.status}")
+            await asyncio.sleep(1)
+
+    def _create_cls(self):
+        #   NOTE: this is ugly, but we're waiting for https://github.com/golemfactory/yapapi/issues/372
+        class_name = 'Service_' + uuid.uuid4().hex
+        return type(class_name, (ServiceBase,), {'_yhc_cluster': self})
 
 
 class YagnaTransport(httpx.AsyncBaseTransport):
@@ -25,59 +57,31 @@ class YagnaTransport(httpx.AsyncBaseTransport):
 class Session:
     def __init__(self, executor_cfg):
         self.manager = ServiceManager(executor_cfg)
-        self.service_defs = {}
+        self.clusters = {}
 
     def startup(self, url, image_hash, cnt=1):
-        if url in self.service_defs:
+        if url in self.clusters:
             raise KeyError(f'Service for url {url} already exists')
 
         def define_service(start_steps):
-            request_queue = asyncio.Queue()
-            self.service_defs[url] = {
-                'image_hash': image_hash,
-                'start_steps': start_steps,
-                'queue': request_queue,
-                'cnt': cnt,
-                'service_wrappers': []
-            }
+            self.clusters[url] = Cluster(self.manager, image_hash, start_steps, cnt)
 
         return define_service
 
     @asynccontextmanager
     async def client(self, *args, **kwargs):
-        await self.start_new_services()
+        self.start_new_services()
 
         mounts = kwargs.pop('mounts', {})
-        for url, service_def in self.service_defs.items():
-            mounts[url] = YagnaTransport(service_def['queue'])
-        kwargs['mounts'] = mounts
+        yagna_mounts = {url: YagnaTransport(cluster.request_queue) for url, cluster in self.clusters.items()}
+        kwargs['mounts'] = {**mounts, **yagna_mounts}
 
         async with httpx.AsyncClient(*args, **kwargs) as client:
             yield client
 
-    async def start_new_services(self):
-        start_services = []
-
-        for url, service_def in self.service_defs.items():
-            expected_cnt = service_def['cnt']
-            current_cnt = len(service_def['service_wrappers'])
-            start_services += [self._start_service(url) for _ in range(current_cnt, expected_cnt)]
-
-        await asyncio.gather(*start_services)
-
-    async def _start_service(self, url):
-        #   NOTE: this additional class is because we're waiting for https://github.com/golemfactory/yapapi/issues/372
-        class_name = 'Service' + re.sub(r'\W', '', url)
-        cls = type(class_name, (ServiceBase,), {'_service_def': self.service_defs[url]})
-
-        service_wrapper = self.manager.create_service(cls)
-        self.service_defs[url]['service_wrappers'].append(service_wrapper)
-
-        while True:
-            if service_wrapper.status == 'running':
-                return
-            print(f"{url} status: {service_wrapper.status}")
-            await asyncio.sleep(1)
+    def start_new_services(self):
+        [cluster.start() for cluster in self.clusters.values()]
 
     async def close(self):
+        [cluster.stop() for cluster in self.clusters.values()]
         await self.manager.close()

--- a/yagna_requests/session.py
+++ b/yagna_requests/session.py
@@ -1,0 +1,52 @@
+import re
+import asyncio
+from contextlib import asynccontextmanager
+
+import httpx
+from yapapi_service_manager import ServiceManager
+
+from .service_base import ServiceBase
+
+
+class Session:
+    def __init__(self, executor_cfg):
+        self.manager = ServiceManager(executor_cfg)
+        self.service_defs = {}
+        self.service_wrappers = {}
+
+    def startup(self, url, image_hash):
+        if url in self.service_defs:
+            raise KeyError(f'Service for url {url} already exists')
+
+        def define_service(start_steps):
+            self.service_defs[url] = {'image_hash': image_hash, 'start_steps': start_steps}
+
+        return define_service
+
+    @asynccontextmanager
+    async def client(self, *args, **kwargs):
+        await self.start_new_services()
+        async with httpx.AsyncClient(*args, **kwargs) as client:
+            yield client
+
+    async def start_new_services(self):
+        new_urls = [url for url in self.service_defs.keys() if url not in self.service_wrappers]
+        start_services = [self._start_service(url) for url in new_urls]
+        await asyncio.gather(*start_services)
+
+    async def _start_service(self, url):
+        #   NOTE: this additional class is because we're waiting for https://github.com/golemfactory/yapapi/issues/372
+        class_name = 'Service' + re.sub(r'\W', '', url)
+        cls = type(class_name, (ServiceBase,), {'_service_def': self.service_defs[url]})
+
+        service_wrapper = self.manager.create_service(cls)
+        self.service_wrappers[url] = service_wrapper
+
+        while True:
+            if service_wrapper.status == 'running':
+                return
+            print(f"{url} status: {service_wrapper.status}")
+            await asyncio.sleep(1)
+
+    async def close(self):
+        await self.manager.close()


### PR DESCRIPTION
# WHAT

https://golemproject.atlassian.net/browse/APPS-122?atlOrigin=eyJpIjoiYWE5NzNhMDQzMTg0NDlhY2E2NDQ4NzVlNGFmZGJhN2YiLCJwIjoiaiJ9

Pretty advanced Yagna Requests POC. Things done:
* more-or-less final interface
* single simple example
* load balancing
* provider recycling (no request is lost, even if we have to replace the provider)

Also check TODO section.

# WHY

1. Create a nice interface for the (hopefully?) very common usage of Golem
2. Create a "sexy" library - easy to use, with useful features & just working well
3. Investigate load balancing and provider recycling

# REVIEW NOTES

Installation & running:
```
pip3 install git+https://github.com/golemfactory/yagna-requests.git@9972ada
git clone git@github.com:golemfactory/yagna-requests.git
cd yagna-requests
git checkout 9972ada

# IMPORTANT NOTE
# it is assumed in ~/yapapi you have yapapi on 1d28985 (this version was used for the development)
PYTHONPATH=~/yapapi:$PYTHONPATH python3 examples/calculator/run_calculator.py
```

You should see:
* concurrent agreements with 3 providers
* 50 different "CALCULATED" & graceful shutdown
* ~5 exceptions with message "ooops, failed ...", that stop the agreement & start another one (this simulates provider error)



Parts already reviewed in `http-requestor-proxy`:
* `yagna_requests/serializable_request.py` except `from_httpx_handle_request_args` function
* `yagna_requests/__main__.py`

# TODO

1. Rename. I think about `yagna-httpx-client`, because we use `httpx` instead of `requests` and also `httpx`-like client is the only feature.
2. Installation & requirements. Currently the same code is installed on the provider and requestor side, but
* only small part is really shared (`serializable_request.py`)
* requirements are different
--> Maybe `pip install yagna-httpx-client[requestor]`?
3. Tests. Requests serialization should just work for every possible request. Those tests were already written for `http-requestor-proxy`, they just need to be moved here.
4. More examples:
* example with more than one `@startup`
* `http-requestor-proxy` as example usage
5. Some functions in `serializable_request.py` are not used anymore (but could be useful e.g. for `http-requestor-proxy` example)
6. Library should let the developer change the number of providers. Maybe some auto-load-balancer could be implemented as a POC? More general: think once again about the interface.