### PR TITLE
Test for the serializable_request

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,10 @@ setuptools.setup(
         "httpx==0.18.2",
         "yapapi-service-manager @ git+https://github.com/golemfactory/yapapi-service-manager.git",
     ],
+    tests_require=[
+        "pytest==6.2.3",
+        "pytest-asyncio==0.15.1",
+    ],
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/tests/echo_server/Dockerfile
+++ b/tests/echo_server/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim
+
+WORKDIR /golem/work
+VOLUME /golem/work
+
+#   This is necessary only as long as we install yagna-requests from git
+RUN apt-get update && \
+    apt-get install -y git
+RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
+
+#   Install dependencies & code
+RUN pip install Flask==2.0.1 gunicorn==20.1.0
+COPY echo_server.py /golem/run/echo_server.py

--- a/tests/echo_server/echo_server.py
+++ b/tests/echo_server/echo_server.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from yagna_requests.serializable_request import Request
+
+HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']
+app = Flask(__name__)
+
+
+@app.route('/', defaults={'path': ''}, methods=HTTP_METHODS)
+@app.route('/<path:path>', methods=HTTP_METHODS)
+def echo(path):
+    '''
+    Whole request is returned (including headers etc) to simplify testing.
+    Echo server has no non-testing purpose.
+    '''
+    req = Request.from_flask_request()
+    out_data = {
+        'echo': 'echo',
+        'req': req.as_dict(),
+    }
+    return out_data, 200

--- a/tests/sample_requests.py
+++ b/tests/sample_requests.py
@@ -1,0 +1,8 @@
+from httpx import Request
+
+SAMPLE_URL = "http://hi.my.name.is.golem"
+
+sample_requests = [
+    Request("GET", SAMPLE_URL + '/add/1/2'),
+    Request("GET", SAMPLE_URL + '/add/2/3'),
+]

--- a/tests/sample_requests.py
+++ b/tests/sample_requests.py
@@ -1,8 +1,21 @@
-from httpx import Request
 
-SAMPLE_URL = "http://hi.my.name.is.golem"
+BASE_URL = 'http://hi.my.name.is.golem'
 
 sample_requests = [
-    Request("GET", SAMPLE_URL + '/add/1/2'),
-    Request("GET", SAMPLE_URL + '/add/2/3'),
+    ('GET', BASE_URL, {}),
+    ('GET', BASE_URL + '/some/path', {}),
+    ('GET', BASE_URL + '/some/path/7', {'params': (('x', 7), ('y', 8))}),
+    ('GET', BASE_URL + '/some/path/7', {'params': (('x', 7), ('y', 8))}),
+
+    ('patch', BASE_URL, {'headers': {'user-agent': 'my-app/0.0.1'}}),
+    ('patch', BASE_URL, {'headers': {'accept-encoding': 'gzip', 'user-agent': 'aaa'}}),
+    ('GET', BASE_URL, {'cookies': {'peanut': 'butter'}}),
+
+    ('PUT', BASE_URL + '/file', {
+        'files': {'some-file': open('.gitignore', 'rb'),
+                  'other-file': open('tests/echo_server/echo_server.py', 'r')}}),
+    ('post', BASE_URL, {'data': {'x': 'y'}}),
+    ('post', BASE_URL, {'json': {'x': ['y', 'z', {'a': 7}]}}),
+    ('POST', BASE_URL + '/some/path/?a=11', {'data': {'x': 77, 'y': 88}}),
+    ('POST', BASE_URL, {'content': b'gAUygauygaihua\x32'}),
 ]

--- a/tests/test_serializable_request.py
+++ b/tests/test_serializable_request.py
@@ -1,0 +1,76 @@
+'''
+E2E test for "all" possible requests. Test goes like this:
+1. Initialize a few services with echo-like server
+2. For each predefined request
+    *   send it to the provider
+    *   ensure response contains the original request
+
+This tests various serialization-related methods of seriablizable_request.Request/Response
+classes, in this order:
+    Called when request is being sent to the provider:
+        Request.from_httpx_handle_request_args
+        Request.to_file
+    Called on provider
+        Request.from_file
+        Request.as_requests_request
+        Response.from_requests_response
+        Response.to_file
+    Called when response from the provider is processed:
+        Response.from_file
+    Called directly here, to compare with the original request
+        Request.from_json
+        Request.as_httpx_request
+
+NOTE: there are some other methods defined on those objects and they are *not* tested here.
+'''
+import asyncio
+
+import pytest
+
+from .sample_requests import sample_requests, SAMPLE_URL
+from yagna_requests import Session
+
+
+EXECUTOR_CFG = {
+    'budget': 1,
+    'subnet_tag': 'devnet-beta.2',
+}
+
+STARTUP_CFG = {
+    'url': SAMPLE_URL,
+    'image_hash': '040e5b765dcf008d037d5b840cf8a9678641b0ddd3b4fe3226591a11',
+    'service_cnt': 1,
+}
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    '''
+    We want to have a single event loop for a whole testing session https://stackoverflow.com/a/49940520/15851655
+    '''
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()
+
+
+def echo_server_startup(ctx, listen_on):
+    ctx.run("/usr/local/bin/gunicorn", "--chdir", "/golem/run", "-b", listen_on, "calculator_server:app", "--daemon")
+
+
+@pytest.fixture(scope='session')
+async def client():
+    #   TODO command arg for subnet_tag
+    session = Session(EXECUTOR_CFG)
+    session.startup(**STARTUP_CFG)(echo_server_startup)
+    async with session.client() as client:
+        yield client
+    await session.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('src_req', sample_requests)
+async def test_on_provider(client, src_req):
+    response = await client.send(src_req)
+    print(response)
+    print(response.content.decode())
+    assert True

--- a/yagna_requests/serializable_request.py
+++ b/yagna_requests/serializable_request.py
@@ -85,6 +85,10 @@ class Request:
     @classmethod
     def from_json(cls, json_data):
         data = json.loads(json_data)
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data):
         return cls(
             data['method'],
             data['url'],
@@ -108,6 +112,15 @@ class Request:
         data = stream.read()
 
         return cls(method, url, data, headers)
+
+    @classmethod
+    def from_httpx_request(cls, req):
+        return cls(
+            req.method,
+            str(req.url),
+            req.read(),
+            dict(req.headers),
+        )
 
     def to_file(self, fname):
         with open(fname, 'w') as f:


### PR DESCRIPTION
[APPS-212](https://golemproject.atlassian.net/browse/APPS-212)

**WHY**

We want to correctly serialize *any* request/response.
The only way to achieve this is to try at least a few different requests.

**WHAT**

Run tests: `$ pytest` (assumes there is a `yagna` daemon running, `yagna-request` dependencies and testing dependencies are installed).

Tests are not very exhaustive, but they cover a great bunch of cases.