### PR TITLE
different dependencies installed on requestor/provider

### DIFF
--- a/examples/calculator/calculator.Dockerfile
+++ b/examples/calculator/calculator.Dockerfile
@@ -1,14 +1,16 @@
 FROM python:3.8-slim
 
 WORKDIR /golem/work
-VOLUME /golem/work
+VOLUME  /golem/work
 
-#   This is necessary only as long as we install yagna-requests from git
-RUN apt-get update && \
-    apt-get install -y git
-
-#   This is *required* in every image that is supposed to work with yagna-requests
-RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/improved-installation-APPS-213#egg=yagna-requests[provider]
+#   Install yagna-requests. This could be done also with
+#   RUN pip install git+https://github.com/golemfactory/yagna-requests.git#egg=yagna-requests[provider]
+#   but this way is much more convenient during the development.
+COPY yagna_requests yagna_requests
+COPY setup.py       setup.py
+COPY README.md      README.md
+RUN pip install .[provider]
+RUN rm -r *
 
 #   And this is calculator-related code (this part will be different in other examples). 
 RUN pip install Flask==2.0.1 gunicorn==20.1.0

--- a/examples/calculator/calculator.Dockerfile
+++ b/examples/calculator/calculator.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y git
 
 #   This is *required* in every image that is supposed to work with yagna-requests
-RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
+RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/improved-installation-APPS-213#egg=yagna-requests[provider]
 
 #   And this is calculator-related code (this part will be different in other examples). 
 RUN pip install Flask==2.0.1 gunicorn==20.1.0

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -8,7 +8,7 @@ session = Session(executor_cfg)
 
 @session.startup(
     url='http://calc',
-    image_hash='cc1b3087abaf183704f57c50fa8fe1a6803e7c356cb991b68164bc69',
+    image_hash='78be48312b494ac182ee3dd2d8ddb9bc2059000d42366528c51f3986',
     service_cnt=3,
 )
 def calculator_startup(ctx, listen_on):

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -8,7 +8,7 @@ session = Session(executor_cfg)
 
 @session.startup(
     url='http://calc',
-    image_hash='78be48312b494ac182ee3dd2d8ddb9bc2059000d42366528c51f3986',
+    image_hash='5c541543ed50237dfd6c70c526cc5d0aac0513cbb04231b1f4f53ef4',
     service_cnt=3,
 )
 def calculator_startup(ctx, listen_on):

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from yagna_requests import Session
+from yagna_requests.session import Session
 
 executor_cfg = {'budget': 10, 'subnet_tag': 'devnet-beta.2'}
 session = Session(executor_cfg)
@@ -8,7 +8,7 @@ session = Session(executor_cfg)
 
 @session.startup(
     url='http://calc',
-    image_hash='040e5b765dcf008d037d5b840cf8a9678641b0ddd3b4fe3226591a11',
+    image_hash='cc1b3087abaf183704f57c50fa8fe1a6803e7c356cb991b68164bc69',
     service_cnt=3,
 )
 def calculator_startup(ctx, listen_on):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ provider_requirements = [
     "requests-unixsocket==0.2.0",
     "click==8.0.1",
 ]
-test_requirements = [
+test_requirements = requestor_requirements.copy()
+test_requirements += [
     "pytest==6.2.3",
     "pytest-asyncio==0.15.1",
 ]
@@ -38,8 +39,9 @@ setuptools.setup(
     extras_require={
         'requestor': requestor_requirements,
         'provider': provider_requirements,
+        'tests': test_requirements,
     },
-    tests_require=requestor_requirements + test_requirements,
+    tests_require=test_requirements,
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,21 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
+requestor_requirements = [
+    "httpx==0.18.2",
+    "yapapi-service-manager @ git+https://github.com/golemfactory/yapapi-service-manager.git",
+]
+provider_requirements = [
+    "requests==2.25.1",
+    "requests-unixsocket==0.2.0",
+]
+test_requirements = [
+    "pytest==6.2.3",
+    "pytest-asyncio==0.15.1",
+]
+
+
 setuptools.setup(
     name="yagna-requests",
     version="0.0.0",
@@ -14,16 +29,16 @@ setuptools.setup(
     url="https://handbook.golem.network/yapapi/",
     download_url="https://github.com/golemfactory/yagna-requests",
     packages=setuptools.find_packages(),
-    install_requires=[
-        "requests==2.25.1",
-        "requests-unixsocket==0.2.0",
-        "httpx==0.18.2",
-        "yapapi-service-manager @ git+https://github.com/golemfactory/yapapi-service-manager.git",
-    ],
-    tests_require=[
-        "pytest==6.2.3",
-        "pytest-asyncio==0.15.1",
-    ],
+
+    #   NOTE: all requirements are in "extras", because there are no common dependencies
+    #         for the requestor and provider side, so the library has to be installed either
+    #         as [provider] or as [requestor]
+    install_requires=[],
+    extras_require={
+        'requestor': requestor_requirements,
+        'provider': provider_requirements,
+    },
+    tests_require=requestor_requirements + test_requirements,
     classifiers=[
         "Development Status :: 0 - Alpha",
         "Framework :: YaPaPI",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ requestor_requirements = [
 provider_requirements = [
     "requests==2.25.1",
     "requests-unixsocket==0.2.0",
+    "click==8.0.1",
 ]
 test_requirements = [
     "pytest==6.2.3",

--- a/tests/echo_server/Dockerfile
+++ b/tests/echo_server/Dockerfile
@@ -6,7 +6,7 @@ VOLUME /golem/work
 #   This is necessary only as long as we install yagna-requests from git
 RUN apt-get update && \
     apt-get install -y git
-RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/poc-APPS-122
+RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/improved-installation-APPS-213#egg=yagna-requests[provider]
 
 #   Install dependencies & code
 RUN pip install Flask==2.0.1 gunicorn==20.1.0

--- a/tests/echo_server/Dockerfile
+++ b/tests/echo_server/Dockerfile
@@ -1,13 +1,17 @@
 FROM python:3.8-slim
 
 WORKDIR /golem/work
-VOLUME /golem/work
+VOLUME  /golem/work
 
-#   This is necessary only as long as we install yagna-requests from git
-RUN apt-get update && \
-    apt-get install -y git
-RUN pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/improved-installation-APPS-213#egg=yagna-requests[provider]
+#   Install yagna-requests. This could be done also with
+#   RUN pip install git+https://github.com/golemfactory/yagna-requests.git#egg=yagna-requests[provider]
+#   but this way is much more convenient during the development.
+COPY yagna_requests yagna_requests
+COPY setup.py       setup.py
+COPY README.md      README.md
+RUN pip install .[provider]
+RUN rm -r *
 
 #   Install dependencies & code
 RUN pip install Flask==2.0.1 gunicorn==20.1.0
-COPY echo_server.py /golem/run/echo_server.py
+COPY tests/echo_server/echo_server.py /golem/run/echo_server.py

--- a/tests/test_serializable_request.py
+++ b/tests/test_serializable_request.py
@@ -1,7 +1,8 @@
 '''
 E2E tests for many different requests. Test goes like this:
 1. Initialize a few services with echo-like server
-2. For each predefined httpx.Request:
+2. For each predefined request definition
+    *   create a httpx.Request
     *   send it to the provider
     *   ensure response contains the original request
 
@@ -42,8 +43,8 @@ EXECUTOR_CFG = {
 
 STARTUP_CFG = {
     'url': BASE_URL,
-    #   Image created from `docker build tests/echo_server/`
-    'image_hash': 'cadb48ec91b7f162666afcca98e6ebfb8215649411373861a26d7f07',
+    #   Image created from `docker build . -f tests/echo_server/Dockerfile`
+    'image_hash': 'ad5cb060b69f6097ab41431f56a9b81e18e60d423b267eb16b090585',
     'service_cnt': 1,
 }
 

--- a/tests/test_serializable_request.py
+++ b/tests/test_serializable_request.py
@@ -43,7 +43,7 @@ EXECUTOR_CFG = {
 STARTUP_CFG = {
     'url': BASE_URL,
     #   Image created from `docker build tests/echo_server/`
-    'image_hash': '39fc9be3ffef142ae02c57a398d87e4a0ffc32c22c2497516e955466',
+    'image_hash': 'cadb48ec91b7f162666afcca98e6ebfb8215649411373861a26d7f07',
     'service_cnt': 1,
 }
 

--- a/tests/test_serializable_request.py
+++ b/tests/test_serializable_request.py
@@ -32,7 +32,8 @@ import asyncio
 import pytest
 
 from .sample_requests import sample_requests, BASE_URL
-from yagna_requests import Session, serializable_request
+from yagna_requests.session import Session
+from yagna_requests import serializable_request
 
 EXECUTOR_CFG = {
     'budget': 1,

--- a/yagna_requests/__init__.py
+++ b/yagna_requests/__init__.py
@@ -1,1 +1,0 @@
-from .session import Session

--- a/yagna_requests/serializable_request.py
+++ b/yagna_requests/serializable_request.py
@@ -1,4 +1,3 @@
-import requests
 import json
 from urllib.parse import urlsplit, urlunsplit
 
@@ -24,7 +23,7 @@ class Response:
         )
 
     @classmethod
-    def from_requests_response(cls, res: requests.Response):
+    def from_requests_response(cls, res):
         return cls(res.status_code, res.content, dict(res.headers))
 
     def to_file(self, fname):
@@ -138,6 +137,8 @@ class Request:
         }
 
     def as_requests_request(self):
+        #   Imported here, because we use this only on the provider side
+        import requests
         req = requests.Request(
             method=self.method,
             url=self.url,


### PR DESCRIPTION
[APPS-213](https://golemproject.atlassian.net/browse/APPS-213)

**NOTE**
This is supposed to be merged to `main` after https://github.com/golemfactory/yagna-requests/pull/2, not to the apps-212 branch.

**WHY**
This library is installed both on the requestor and on the provider.
Because there is only a little code really shared (namely `yagna_requests.serializable_request`), dependencies on provider/requestor are different. We don't want to install everything everywhere.

**WHAT**
```
$ python3 -m pip install yagna_requests[provider]
$ python3 -m pip install yagna_requests[requestor]

# and also
$ python3 -m pip install yagna_requests[tests]
```

**HOW TO TEST**
Scenario 1:
```
$ python3 -m pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/improved-installation-APPS-213#egg=yagna-requests[requestor]
$ python3 examples/calculator/run_calculator.py
# (wait for a line in logs starting with CALCULATED and stop)
```

Scenario 2:
```
$ python3 -m pip install git+https://github.com/golemfactory/yagna-requests.git@johny-b/improved-installation-APPS-213#egg=yagna-requests[tests]
$ pytest -sx
```

