### PR TITLE
dynamic provider allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,77 @@
 # ya-httpx-client
 
-## PLANNED FEATURES
 
-* additional more complex example, with multiple servers
+## Quickstart
 
+```python
+#   1.  Initialize the session with yapapi.Golem configuration. This should be done exactly once. 
+executor_cfg = {'budget': 10, 'subnet_tag': 'devnet-beta.2'}
+session = Session(executor_cfg)
+
+#   2.  Define a service. You may define as many services as you want, provided they have different urls.
+@session.startup(
+    #   All http requests directed to host "any_name" will be processed by ...
+    url='http://any_name',
+    #   ...a service running on provider, in VM based on this image ...
+    image_hash='25f09e17c34433f979331edf4f3b47b2ca330ba2f8acbfe2e3dbd9c3',
+    #   ... and to be more exact, by one of indistinguishable services running on different providers.
+    #   This is the initial number of services that can be changed at any time by session.set_size().
+    #   Also check "load balancing" section.
+    init_size=1
+)
+def calculator_startup(ctx, listen_on):
+    #   Start the http server in the background (service will be operating only after this finished).
+    ctx.run("sh", "-c", "start_my_http_server.sh")
+
+#   3.  Use the service(s)
+async def run():
+    async with session.client() as client:
+        req_url = 'http://any_name/do/something'
+        res = await client.post(req_url, json={'foo': 'bar'})
+        assert res.status_code == 200
+
+    #   This is necessary for a graceful shutdown
+    await session.close()
+
+#   4.  Optional: change the number of services. Check "load balancing" section for more details.
+session.set_size('http://any_name', 7)
+```
+
+## Load balancing
+
+By default, a single instance of a service is created. We can change this by setting `init_size` in `@session.startup`
+to a different value, or by calling `session.set_size`. This value doesn't have to be an integer, it might also be a
+callable that takes a `ya_httpx_client.session.Cluster` object as an argument and returns integer:
+
+```python
+def calculate_new_size(cluster):
+    if cluster.request_queue.qsize() > 7:
+        return 2
+    else:
+        return 1
+session.set_size('http://any_name', calculate_new_size)
+```
+
+or even better, anything that could be evaluated as an integer:
+
+```python
+class LoadBalancer:
+    def __init__(self, cluster):
+        self.cluster = cluster
+    
+    def __int__(self):
+        if self.cluster.request_queue.empty():
+            return 0
+        return 1
+session.set_size('http://any_name', LoadBalancer)
+```
+
+If the last case, we have no control on how often `int(load_balancer_object)` will be called, so the implementation
+should be a little more clever, at least to avoid too frequent changes - check `ya_httpx_client.provider_auto_balance.SimpleLoadBalancer`
+for an example.
+    
 ## Possible improvements
 
-* `startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done
+*   `startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done
+*   `on_service_stop` = [restart, raise, ignore]
+*   faster communication when the VPN is ready

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ session.set_size('http://any_name', LoadBalancer)
 ```
 
 If the last case, we have no control on how often `int(load_balancer_object)` will be called, so the implementation
-should be a little more clever, at least to avoid too frequent changes - check `ya_httpx_client.provider_auto_balance.SimpleLoadBalancer`
+should be a little more clever, at least to avoid too frequent changes - check [SimpleLoadBalancer](ya_httpx_client/provider_auto_balance)
 for an example.
     
 ## Possible improvements

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ session.set_size('http://any_name', 7)
 
 By default, a single instance of a service is created. We can change this by setting `init_size` in `@session.startup`
 to a different value, or by calling `session.set_size`. This value doesn't have to be an integer, it might also be a
-callable that takes a `ya_httpx_client.session.Cluster` object as an argument and returns integer:
+callable that takes a `ya_httpx_client.session.Cluster` object as an argument and returns an integer:
 
 ```python
 def calculate_new_size(cluster):
@@ -67,11 +67,7 @@ session.set_size('http://any_name', LoadBalancer)
 ```
 
 If the last case, we have no control on how often `int(load_balancer_object)` will be called, so the implementation
-should be a little more clever, at least to avoid too frequent changes - check [SimpleLoadBalancer](ya_httpx_client/provider_auto_balance)
+should be a little more clever, at least to avoid too frequent changes - check [SimpleLoadBalancer](ya_httpx_client/provider_auto_balance.py)
 for an example.
-    
-## Possible improvements
 
-*   `startup` might be optional when https://github.com/golemfactory/yagna/issues/1350 is done
-*   `on_service_stop` = [restart, raise, ignore]
-*   faster communication when the VPN is ready
+NOTE: setting size to anything other than an integer this should be considered an experimental feature.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ya-httpx-client
 
+Communicate with a provider-based http server the way you communicate with any other http server
 
 ## Quickstart
 
@@ -15,9 +16,9 @@ session = Session(executor_cfg)
     #   ...a service running on provider, in VM based on this image ...
     image_hash='25f09e17c34433f979331edf4f3b47b2ca330ba2f8acbfe2e3dbd9c3',
     #   ... and to be more exact, by one of indistinguishable services running on different providers.
-    #   This is the initial number of services that can be changed at any time by session.set_size().
+    #   This is the initial number of services that can be changed at any time by session.set_cluster_size().
     #   Also check "load balancing" section.
-    init_size=1
+    init_cluster_size=1
 )
 def calculator_startup(ctx, listen_on):
     #   Start the http server in the background (service will be operating only after this finished).
@@ -34,13 +35,13 @@ async def run():
     await session.close()
 
 #   4.  Optional: change the number of services. Check "load balancing" section for more details.
-session.set_size('http://any_name', 7)
+session.set_cluster_size('http://any_name', 7)
 ```
 
 ## Load balancing
 
-By default, a single instance of a service is created. We can change this by setting `init_size` in `@session.startup`
-to a different value, or by calling `session.set_size`. This value doesn't have to be an integer, it might also be a
+By default, a single instance of a service is created. We can change this by setting `init_cluster_size` in `@session.startup`
+to a different value, or by calling `session.set_cluster_size`. This value doesn't have to be an integer, it might also be a
 callable that takes a `ya_httpx_client.session.Cluster` object as an argument and returns an integer:
 
 ```python
@@ -49,7 +50,7 @@ def calculate_new_size(cluster):
         return 2
     else:
         return 1
-session.set_size('http://any_name', calculate_new_size)
+session.set_cluster_size('http://any_name', calculate_new_size)
 ```
 
 or even better, anything that could be evaluated as an integer:
@@ -63,11 +64,11 @@ class LoadBalancer:
         if self.cluster.request_queue.empty():
             return 0
         return 1
-session.set_size('http://any_name', LoadBalancer)
+session.set_cluster_size('http://any_name', LoadBalancer)
 ```
 
 If the last case, we have no control on how often `int(load_balancer_object)` will be called, so the implementation
 should be a little more clever, at least to avoid too frequent changes - check [SimpleLoadBalancer](ya_httpx_client/provider_auto_balance.py)
 for an example.
 
-NOTE: setting size to anything other than an integer this should be considered an experimental feature.
+NOTE: setting size to anything other than an integer should be considered an experimental feature.

--- a/examples/calculator/run_calculator.py
+++ b/examples/calculator/run_calculator.py
@@ -9,7 +9,7 @@ session = Session(executor_cfg)
 @session.startup(
     url='http://calc',
     image_hash='25f09e17c34433f979331edf4f3b47b2ca330ba2f8acbfe2e3dbd9c3',
-    service_cnt=3,
+    init_size=3,
 )
 def calculator_startup(ctx, listen_on):
     ctx.run("/usr/local/bin/gunicorn", "--chdir", "/golem/run", "-b", listen_on, "calculator_server:app", "--daemon")

--- a/tests/test_serializable_request.py
+++ b/tests/test_serializable_request.py
@@ -1,6 +1,6 @@
 '''
 E2E tests for many different requests. Test goes like this:
-1. Initialize a few services with echo-like server
+1. Initialize a service with echo-like server
 2. For each predefined request definition
     *   create a httpx.Request
     *   send it to the provider
@@ -45,7 +45,6 @@ STARTUP_CFG = {
     'url': BASE_URL,
     #   Image created from `docker build . -f tests/echo_server/Dockerfile`
     'image_hash': 'bdadcf8955356d10c025411a2b47cabe67a4668f3603499737e8d74d',
-    'service_cnt': 1,
 }
 
 

--- a/ya_httpx_client/provider_auto_balance.py
+++ b/ya_httpx_client/provider_auto_balance.py
@@ -22,7 +22,8 @@ class SimpleLoadBalancer:
 
     def __int__(self):
         '''
-        Recalculate desired number of providers each 10 seconds.
+        Returns the desirde number of providers.
+        To avoid too frequent changes we recalculate the number at most once in every 10 seconds.
         '''
         now = datetime.now()
         if self.cnt is None or (now - self.prev_queue_check_at).seconds > 10:

--- a/ya_httpx_client/provider_auto_balance.py
+++ b/ya_httpx_client/provider_auto_balance.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING
+from datetime import datetime
+if TYPE_CHECKING:
+    from ya_httpx_client.session import Cluster
+
+
+class SimpleLoadBalancer:
+    '''
+    NOTE: this implementation is only an example how such things should be done.
+
+    Implemented logic doesn't make much sense, but I don't think it's possible to
+    create a very good load balancer without any knowledge of a particular task
+    it will be used for.
+    '''
+
+    MAX_PROVIDER_CNT = 5
+
+    def __init__(self, cluster: 'Cluster'):
+        self.cluster = cluster
+
+        self.cnt, self.prev_queue_size, self.prev_queue_check_at = None, None, None
+
+    def __int__(self):
+        '''
+        Recalculate desired number of providers each 10 seconds.
+        '''
+        now = datetime.now()
+        if self.cnt is None or (now - self.prev_queue_check_at).seconds > 10:
+            self.cnt = self._calculate_new_cnt()
+            self.prev_queue_size = self.cluster.request_queue.qsize()
+            self.prev_queue_check_at = now
+        return self.cnt
+
+    def _calculate_new_cnt(self) -> int:
+        current_cnt = self.cnt
+        current_queue_size = self.cluster.request_queue.qsize()
+
+        if current_cnt is None:
+            #   Initial value
+            return 3
+        elif not current_queue_size and not self.prev_queue_size:
+            #   Queue is empty now and was empty before -> seems like there's not much work
+            return 1
+        elif self.prev_queue_size < current_queue_size:
+            #   Queue grown in size -> let's add a provider (unless we already reached the limit)
+            return min(self.cnt + 1, self.MAX_PROVIDER_CNT)
+        else:
+            return self.cnt

--- a/ya_httpx_client/session.py
+++ b/ya_httpx_client/session.py
@@ -115,13 +115,13 @@ class Session:
     def set_size(self, url, size):
         self.clusters[url].set_size(size)
 
-    def startup(self, url, image_hash, service_cnt=1):
+    def startup(self, url, image_hash, init_size=1):
         if url in self.clusters:
             raise KeyError(f'Service for url {url} already exists')
 
         def define_service(start_steps):
             self.clusters[url] = Cluster(self.manager, image_hash, start_steps)
-            self.set_size(url, service_cnt)
+            self.set_size(url, init_size)
 
         return define_service
 

--- a/ya_httpx_client/session.py
+++ b/ya_httpx_client/session.py
@@ -1,12 +1,16 @@
 import asyncio
 import uuid
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 import httpx
 from yapapi_service_manager import ServiceManager
 
 from .service_base import ServiceBase
 from .serializable_request import Request
+
+if TYPE_CHECKING:
+    from typing import Callable, Union, SupportsInt
 
 
 class Cluster:
@@ -17,18 +21,28 @@ class Cluster:
        should be merged into the same cluster-wrapper-thingy, but we can't do this without yapapi-side modifications.
        Currently I don't think `yapapi.Cluster` could be used instead of this one.
     '''
-    def __init__(self, manager, image_hash, start_steps):
+    def __init__(self, manager: ServiceManager, image_hash: str, start_steps):
         self.manager = manager
         self.image_hash = image_hash
         self.start_steps = start_steps
 
-        self.expected_cnt = 0
+        #   This is how many services we want to have running. It is set here to 0, but curretly
+        #   every Cluster initialization is followed by a call to set_size, so this doesn't really matter.
+        self.expected_cnt: 'Union[int, SupportsInt]' = 0
 
-        self.request_queue = asyncio.Queue()
-        self.cls = self._create_cls()
-
+        #   Task that starts new services will be stored here (created later, because now we might not
+        #   have a loop running yet)
         self.new_services_starter_task = None
+
+        #   Each task in this lists corresponds to a single instance of yapapi_service_manager.ServiceWrapper
+        #   (and thus to a single instance of a running service, assuming it already started)
         self.manager_tasks = []
+
+        #   This queue is filled by YagnaTransport and emptied by Service instances
+        self.request_queue = asyncio.Queue()
+
+        #   This is a workaround for a missing yapapi feature
+        self.cls = self._create_cls()
 
     @property
     def cnt(self):
@@ -45,7 +59,7 @@ class Cluster:
         if self.new_services_starter_task is not None:
             self.new_services_starter_task.cancel()
 
-    def set_size(self, size):
+    def set_size(self, size: 'Union[int, Callable[[Cluster], SupportsInt]]'):
         if isinstance(size, int):
             self.expected_cnt = size
         else:
@@ -54,11 +68,11 @@ class Cluster:
     async def _start_new_services(self):
         while True:
             expected_cnt = int(self.expected_cnt)
-            new_tasks = [asyncio.create_task(self._manage()) for _ in range(self.cnt, expected_cnt)]
+            new_tasks = [asyncio.create_task(self._manage_single_service()) for _ in range(self.cnt, expected_cnt)]
             self.manager_tasks += new_tasks
             await asyncio.sleep(1)
 
-    async def _manage(self):
+    async def _manage_single_service(self):
         service_wrapper = None
 
         while True:
@@ -66,6 +80,7 @@ class Cluster:
                 service_wrapper = self.manager.create_service(self.cls)
 
             if int(self.expected_cnt) < self.cnt:
+                #   There are too many services running, (at least) one has to stop
                 service_wrapper.stop()
                 break
 
@@ -88,7 +103,7 @@ class Cluster:
         #   NOTE: this is ugly, but we're waiting for https://github.com/golemfactory/yapapi/issues/372
         class_name = 'Service_' + uuid.uuid4().hex
 
-        #   NOTE: 'yhc' is from `yapapi-httpx-client', but I hope this will be removed before we release this
+        #   NOTE: 'yhc' is from `ya-httpx-client'
         return type(class_name, (ServiceBase,), {'_yhc_cluster': self})
 
 

--- a/ya_httpx_client/session.py
+++ b/ya_httpx_client/session.py
@@ -17,12 +17,12 @@ class Cluster:
        should be merged into the same cluster-wrapper-thingy, but we can't do this without yapapi-side modifications.
        Currently I don't think `yapapi.Cluster` could be used instead of this one.
     '''
-    def __init__(self, manager, image_hash, start_steps, cnt):
+    def __init__(self, manager, image_hash, start_steps):
         self.manager = manager
         self.image_hash = image_hash
         self.start_steps = start_steps
 
-        self.expected_cnt = cnt
+        self.expected_cnt = 0
 
         self.request_queue = asyncio.Queue()
         self.cls = self._create_cls()
@@ -45,16 +45,18 @@ class Cluster:
         if self.new_services_starter_task is not None:
             self.new_services_starter_task.cancel()
 
-    def resize(self, new_cnt):
-        self.expected_cnt = new_cnt
+    def set_size(self, size):
+        if isinstance(size, int):
+            self.expected_cnt = size
+        else:
+            self.expected_cnt = size(self)
 
     async def _start_new_services(self):
         while True:
-            new_tasks = [asyncio.create_task(self._manage()) for _ in range(self.cnt, self.expected_cnt)]
-            if new_tasks:
-                print(f"CREATED {len(new_tasks)} NEW TASKS")
+            expected_cnt = int(self.expected_cnt)
+            new_tasks = [asyncio.create_task(self._manage()) for _ in range(self.cnt, expected_cnt)]
             self.manager_tasks += new_tasks
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(1)
 
     async def _manage(self):
         service_wrapper = None
@@ -63,8 +65,7 @@ class Cluster:
             if service_wrapper is None:
                 service_wrapper = self.manager.create_service(self.cls)
 
-            if self.expected_cnt < self.cnt:
-                print("STOPPING BECAUSE THERE IS TOO MUCH OF US")
+            if int(self.expected_cnt) < self.cnt:
                 service_wrapper.stop()
                 break
 
@@ -111,15 +112,16 @@ class Session:
         self.manager = ServiceManager(executor_cfg)
         self.clusters = {}
 
-    def resize(self, url, cnt):
-        self.clusters[url].resize(cnt)
+    def set_size(self, url, size):
+        self.clusters[url].set_size(size)
 
     def startup(self, url, image_hash, service_cnt=1):
         if url in self.clusters:
             raise KeyError(f'Service for url {url} already exists')
 
         def define_service(start_steps):
-            self.clusters[url] = Cluster(self.manager, image_hash, start_steps, service_cnt)
+            self.clusters[url] = Cluster(self.manager, image_hash, start_steps)
+            self.set_size(url, service_cnt)
 
         return define_service
 

--- a/ya_httpx_client/session.py
+++ b/ya_httpx_client/session.py
@@ -127,7 +127,7 @@ class Session:
         self.manager = ServiceManager(executor_cfg)
         self.clusters = {}
 
-    def set_size(self, url, size):
+    def set_cluster_size(self, url, size):
         self.clusters[url].set_size(size)
 
     def startup(self, url, image_hash, init_size=1):
@@ -136,7 +136,7 @@ class Session:
 
         def define_service(start_steps):
             self.clusters[url] = Cluster(self.manager, image_hash, start_steps)
-            self.set_size(url, init_size)
+            self.set_cluster_size(url, init_size)
 
         return define_service
 


### PR DESCRIPTION
This PR resolves following JIRA ticket

- [APPS-211](https://golemproject.atlassian.net/browse/APPS-211)

## Description

### Why

We want this library to be as useful as possible. Dynamic resource allocation is a useful feature.

### What

1. Number of providers can be changed in a dynamic way, via `session.set_size(URL, HOW_MANY_PROVIDERS)`
2. Up to now number of providers could only be an integer, now it can be also a `Callable[[ya_httpx_cluster.session.Cluster], SupportsInt]`. If this callable returns an object, it will be evaluated in regular periods of time, so any load-balancing could be implemented inside this class.

### GENERAL NOTES ABOUT THIS PR

1. To make this more understandable I added a part of README and some type annotations, but neither of those is complete (they will be completed in the next PR). So please comment on any error, but missing parts are not a concern of this PR.
2. This whole load balancing thing is not very important (even from the POV of this not-very-important library). It works and should be usable, but there is probably quite a lot that could be done to make it more user-friendly.

## Testing instructions

Nothing changed since https://github.com/golemfactory/ya-httpx-client/pull/4, there is no example code that uses load balancing.

The most useful test would be to try to use it, e.g. 
* by setting `init_size` in `examples.calculator.run_calculator.py` to `ya_httpx_client.provider_auto_balance.SimpleLoadBalancer` and checking that the number of running providers changes (in a pretty random way TBH, but this load balancer just doesn't match this example really well, it is less random for higher `max_concurrent_requests` in `add_many_times`).
* or by calling `session.set_size` somewhere